### PR TITLE
Remove max width on images in table cells

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,3 +1,7 @@
 .nowrap {
     white-space: nowrap;
 }
+
+.md-typeset__table, .md-typeset img{
+    max-width: none;
+}


### PR DESCRIPTION
This change should only affect elements with both the .md-typeset__table (mkdocs table class) and .md-typeset img (mkdocs image class)