### PR TITLE
Update button for start menu detection

### DIFF
--- a/docs/Programs/PokemonFRLG/EvTrainer.md
+++ b/docs/Programs/PokemonFRLG/EvTrainer.md
@@ -18,7 +18,7 @@ Repeatedly defeat wild encounters to EV train your Pokémon.
 **Game Settings:**
 
 1. Text Speed: Fast
-2. Button Mode: Help
+2. Button Mode: **NOT L=A**
 3. Frame: Type 1
 
 **Other Setup:**

--- a/docs/Programs/PokemonFRLG/GiftReset.md
+++ b/docs/Programs/PokemonFRLG/GiftReset.md
@@ -33,7 +33,7 @@ This covers the following:
 **Game Settings:**
 
 1. Text Speed: Fast
-2. Button Mode: Help
+2. Button Mode: **NOT L=A**
 3. Frame: Type 1
 
 **Other Setup:**

--- a/docs/Programs/PokemonFRLG/ItemDuplication.md
+++ b/docs/Programs/PokemonFRLG/ItemDuplication.md
@@ -20,7 +20,7 @@ Repeatedly swap Retro Mail with the item Farfetch'd is holding to duplicate it.
 **Game Settings:**
 
 1. Text Speed: Fast
-2. Button Mode: Help
+2. Button Mode: **NOT L=A**
 3. Frame: Type 1
 
 **Other Setup:**

--- a/docs/Programs/PokemonFRLG/LegendaryReset.md
+++ b/docs/Programs/PokemonFRLG/LegendaryReset.md
@@ -33,7 +33,7 @@ This program works for:
 
 1. Text Speed: Fast
 2. Battle Scene: Off
-3. Button Mode: Help
+3. Button Mode: **NOT L=A**
 4. Frame: Type 1
 
 

--- a/docs/Programs/PokemonFRLG/LegendaryRunAway.md
+++ b/docs/Programs/PokemonFRLG/LegendaryRunAway.md
@@ -27,7 +27,7 @@ This program works for:
 
 1. Text Speed: Fast
 2. Battle Scene: Off
-3. Button Mode: Help
+3. Button Mode: **NOT L=A**
 4. Frame: Type 1
 
 **Other Setup:**

--- a/docs/Programs/PokemonFRLG/LuckyEggFarmer.md
+++ b/docs/Programs/PokemonFRLG/LuckyEggFarmer.md
@@ -18,6 +18,13 @@ Repeatedly attempt to catch Chansey and farm Lucky Eggs.
 
 1. Video Resolution: 1080p or higher
 
+**Game Settings:**
+
+1. Text Speed: Fast
+2. Battle Scene: Off
+3. Button Mode: **NOT L=A**
+4. Frame: Type 1
+
 **Other Setup:**
 
 1. Empty your party so that you only have 2 Pokemon:

--- a/docs/Programs/PokemonFRLG/NuggetBridgeFarmer.md
+++ b/docs/Programs/PokemonFRLG/NuggetBridgeFarmer.md
@@ -21,7 +21,7 @@ Repeatedly lose the battle against the undercover Team Rocket Grunt at the end o
 
 1. Text Speed: Fast
 2. Battle Scene: Off
-3. Button Mode: Help
+3. Button Mode: **NOT L=A**
 4. Frame: Type 1
 
 **Other Setup:**

--- a/docs/Programs/PokemonFRLG/PickupFarmer.md
+++ b/docs/Programs/PokemonFRLG/PickupFarmer.md
@@ -18,7 +18,7 @@ Repeatedly defeat low-level wild encounters to farm berries, nuggets, rare candi
 **Game Settings:**
 
 1. Text Speed: Fast
-2. Button Mode: Help
+2. Button Mode: **NOT L=A**
 3. Frame: Type 1
 
 **Other Setup:**

--- a/docs/Programs/PokemonFRLG/PrizeCornerReset.md
+++ b/docs/Programs/PokemonFRLG/PrizeCornerReset.md
@@ -22,7 +22,7 @@ Redeem and soft reset for a shiny Game Corner prize.
 **Game Settings:**
 
 1. Text Speed: Fast
-2. Button Mode: Help
+2. Button Mode: **NOT L=A**
 3. Frame: Type 1
 
 **Other Setup:**

--- a/docs/Programs/PokemonFRLG/RngHelper.md
+++ b/docs/Programs/PokemonFRLG/RngHelper.md
@@ -58,7 +58,7 @@ This program includes options for several RNG targets:
 **Game Settings:**
 
 1. Text Speed: Fast
-2. Button Mode: Help
+2. Button Mode: **NOT L=A**
 3. Frame: Type 1
 4. Mono / Stereo depending on your target Seed
 

--- a/docs/Programs/PokemonFRLG/ShinyHunt-Fishing.md
+++ b/docs/Programs/PokemonFRLG/ShinyHunt-Fishing.md
@@ -22,7 +22,7 @@ This program will shiny hunt by fishing with a pre-registered rod.
 
 1. Text Speed: Fast
 2. Battle Scene: Off
-3. Button Mode: Help
+3. Button Mode: **NOT L=A**
 4. Frame: Type 1
 
 **Other Setup:**

--- a/docs/Programs/PokemonFRLG/ShinyHunt-Overworld.md
+++ b/docs/Programs/PokemonFRLG/ShinyHunt-Overworld.md
@@ -22,7 +22,7 @@ This program will shiny hunt random encounters (grass, cave).
 
 1. Text Speed: Fast
 2. Battle Scene: Off
-3. Button Mode: Help
+3. Button Mode: **NOT L=A**
 4. Frame: Type 1
 
 **Other Setup:**


### PR DESCRIPTION
Now that start menu detection uses the selection arrow we can remove the requirement of "Button Mode: Help"

Updated to specifically mention to not use button mode "L=A"

This should probably wait to go out until the next public release.