### PR TITLE
Add Contributing Guide and Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ mkdocs serve
 
 Then visit http://127.0.0.1:8000 in your browser to see the website.
 
+If you are making multiple changes to the md files, you can add --livereload to the command to automatically refresh the website in your browser when you save changes to md files.
+
+```
+mkdocs serve --livereload
+```
+
 
 ### Building Local Website
 
@@ -112,7 +118,21 @@ MkDocs parses markdown files (.md files) slightly differently than how Github re
 
 - MkDocs defaults all images' max-width to be 100% and height to be "auto" so we shouldn't use image tab attribute "height" in md files to control image sizes. Use width control like `width="500"` or `width="50%"` instead.
 
+### Contributing
 
+Have you written a program and want to share it with the community? Or do you want to improve an existing guide? Please follow the instructions below to add your program to the website!
 
+1. Fork the repository and create a new branch for your program.
+2. Create a new markdown file for your program in the appropriate folder under `docs/Programs/`. 
+    - You can use [docs/Templates/ProgramTemplate.md](docs/Templates/ProgramTemplate.md) as a template for your program's markdown file.
+    - If your program is complex you may want to refer to some of the other complex program guides. [docs/Programs/PokemonLZA/DonutMaker.md](docs/Programs/PokemonLZA/DonutMaker.md) [docs/Programs/PokemonFRLG/RngManipulationGuide.md](docs/Programs/PokemonFRLG/RngManipulationGuide.md)
+3. Most guides include images to illustrate the program. These can be added to the `images/` folder under the program's folder.
+    - In an attempt to improve load times, we recommend converting the images to jpg format and compressing them before uploading.
+    - If you want a detailed photo you can include a large version to be loaded separately `[<img src="images/SmallImage.jpg" width="300">](images/LargeImage.jpg)`
+4. If you are adding a new program guide, make sure to add the program to the correct table in [docs/Programs/index.md](docs/Programs/index.md).
+5. Once you have added your program's markdown file and any associated images, create a pull request to merge your changes into the main branch.
 
+## Some FAQs
+**Q: I added a new doc but it doesn't show up on the nav bar.**
 
+A: If you added a new folder with your doc (e.g. `docs/Programs/PokemonNewGame/MyProgram.md`), make sure to add the folder to `nav` in [mkdocs.yml](mkdocs.yml). mkdocs doesn't automatically add new folders to nav, but it will automatically add new md files within existing folders.

--- a/docs/Templates/ProgramTemplate.md
+++ b/docs/Templates/ProgramTemplate.md
@@ -1,0 +1,50 @@
+<!-- Name Of Program (Populates Nav Bar) -->
+# 
+
+## Program Description
+
+<!-- Short description of the program. Nice to add a screenshot or image to illustrate the program. -->
+
+<img src="images/SomeImage.jpg">
+
+## Instructions
+
+<!-- Add any specific Switch settings required for the program. These are usually the same for all programs. -->
+**Switch Settings:**
+
+1. Screen size: Must be 100% within the Switch settings
+2. [Switch 2: All HDR options must be disabled.](../NintendoSwitch/Switch2Notes.md#switch-2-hdr-may-be-problematic)
+3. [Switch 2: The profile you are using must be the 1st (left-most) profile.](../NintendoSwitch/Switch2Notes.md#resetting-a-game-moves-the-cursor-to-the-1st-user-profile)
+
+<!-- Add any specific PA/Computer settings required for the program. These are usually the same for all programs. -->
+**Program Settings:**
+
+1. Video Resolution: 1080p or higher
+
+<!-- Add settings here that impact the programs reliability. Usually these are game-specific settings. (Text Speed, Battle Animation, etc.) -->
+**Game Settings:**
+
+1. Text Speed: Fast
+2. 
+
+<!-- Guid the user on how to setup in game prior to running the program. Party, Location, Items, etc. -->
+**Other Setup:**
+
+1. Setup instruction 
+    - Extra details
+2. Some more setup instructions if necessary.
+3. 
+
+<!-- Depending on the program, images or diagrams can be nice to assist with setup. -->
+<img src="images/ImageToAssistSetup.jpg">
+
+## Credits
+
+<!-- Add any credits for the program here. This can include authors, contributors, or any other acknowledgments. -->
+- **Author:** 
+
+<hr>
+
+**Discord Server:** 
+
+[<img src="https://canary.discordapp.com/api/guilds/695809740428673034/widget.png?style=banner2">](https://discord.gg/cQ4gWxN)


### PR DESCRIPTION
Added a template for new program guides to help keep them consistent. This should also help avoid the copy paste errors we have seen in the past where a previous guide was copied and changed but the header wasn't updated, duplicating items in the nav bar.

Added a contributing guide with some tips and an FAQ section